### PR TITLE
Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ Pods
 .idea
 
 xcbaselines/
+.build

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "cd6dfb86f496fcd96ce0bc6da962cd936bf41903",
+          "version": "7.3.1"
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/Quick/Quick.git",
+        "state": {
+          "branch": null,
+          "revision": "5fbf13871d185526993130c3a1fad0b70bfe37ce",
+          "version": "1.3.2"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:4.2
+
+import PackageDescription
+
+let package = Package(
+    name: "DataMapper",
+    products: [
+        .library(
+            name: "DataMapper",
+            targets: ["DataMapper"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Quick/Nimble.git", from: "7.0.1"),
+        .package(url: "https://github.com/Quick/Quick.git", from: "1.2.0"),
+    ],
+    targets: [
+        .target(
+            name: "DataMapper",
+            dependencies: [],
+            path: "Source"),
+        .testTarget(
+            name: "DataMapperTests",
+            dependencies: ["DataMapper", "Nimble", "Quick"],
+            path: "Tests"),
+    ]
+)

--- a/Tests/Core/SerializerTest.swift
+++ b/Tests/Core/SerializerTest.swift
@@ -9,6 +9,7 @@
 import Quick
 import Nimble
 import DataMapper
+import Foundation
 
 class SerializerTest: QuickSpec {
 

--- a/Tests/Core/Transformation/Convertibles/URL+SupportedTypeConvertibleTest.swift
+++ b/Tests/Core/Transformation/Convertibles/URL+SupportedTypeConvertibleTest.swift
@@ -9,6 +9,7 @@
 import Quick
 import Nimble
 import DataMapper
+import Foundation
 
 class URL_SupportedTypeConvertibleTest: QuickSpec {
     

--- a/Tests/Core/Transformation/Transformations/Date/CustomDateFormatTransformationTest.swift
+++ b/Tests/Core/Transformation/Transformations/Date/CustomDateFormatTransformationTest.swift
@@ -9,6 +9,7 @@
 import Quick
 import Nimble
 import DataMapper
+import Foundation
 
 class CustomDateFormatTransformationTest: QuickSpec {
     

--- a/Tests/Core/Transformation/Transformations/Date/DateFormatterTransformationTest.swift
+++ b/Tests/Core/Transformation/Transformations/Date/DateFormatterTransformationTest.swift
@@ -9,6 +9,7 @@
 import Quick
 import Nimble
 import DataMapper
+import Foundation
 
 class DateFormatterTransformationTest: QuickSpec {
     

--- a/Tests/Core/Transformation/Transformations/Date/DateTransformationTest.swift
+++ b/Tests/Core/Transformation/Transformations/Date/DateTransformationTest.swift
@@ -9,6 +9,7 @@
 import Quick
 import Nimble
 import DataMapper
+import Foundation
 
 class DateTransformationTest: QuickSpec {
     

--- a/Tests/Core/Transformation/Transformations/Date/ISO8601DateTransformationTest.swift
+++ b/Tests/Core/Transformation/Transformations/Date/ISO8601DateTransformationTest.swift
@@ -9,6 +9,7 @@
 import Quick
 import Nimble
 import DataMapper
+import Foundation
 
 class ISO8601DateTransformationTest: QuickSpec {
     

--- a/Tests/Core/Transformation/Transformations/URLTransformationTest.swift
+++ b/Tests/Core/Transformation/Transformations/URLTransformationTest.swift
@@ -9,6 +9,7 @@
 import Quick
 import Nimble
 import DataMapper
+import Foundation
 
 class URLTransformationTest: QuickSpec {
     

--- a/Tests/JsonSerializer/JsonSerializerTest.swift
+++ b/Tests/JsonSerializer/JsonSerializerTest.swift
@@ -47,7 +47,7 @@ class JsonSerializerTest: QuickSpec {
         }
     }
     
-    private func typedSerializeTest(for type: SupportedType, file: String = #file, line: UInt = #line) {
+    private func typedSerializeTest(for type: SupportedType, file: FileString = #file, line: UInt = #line) {
         let serializer = JsonSerializer()
         
         let data = serializer.typedSerialize(type)
@@ -56,7 +56,7 @@ class JsonSerializerTest: QuickSpec {
         expect(actualType, file: file, line: line) == type
     }
     
-    private func serializeTest(for type: SupportedType, file: String = #file, line: UInt = #line) {
+    private func serializeTest(for type: SupportedType, file: FileString = #file, line: UInt = #line) {
         let serializer = JsonSerializer()
         
         let data = serializer.serialize(type)

--- a/Tests/JsonSerializer/JsonSerializerTest.swift
+++ b/Tests/JsonSerializer/JsonSerializerTest.swift
@@ -9,6 +9,7 @@
 import Quick
 import Nimble
 import DataMapper
+import Foundation
 
 class JsonSerializerTest: QuickSpec {
     


### PR DESCRIPTION
Some changes were necessary to not get errors while compiling tests using `swift test` command. Importing `Foundation` where needed and using `FileString` instead of `String` for `#file` parameters per https://github.com/Quick/Nimble/issues/598.